### PR TITLE
chore: release `create-tutorialkit-rb` v0.1.1

### DIFF
--- a/packages/create-tutorial/package.json
+++ b/packages/create-tutorial/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-tutorialkit-rb",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Interactive tutorials powered by WebContainer API",
   "author": "StackBlitz Inc.",
   "type": "module",


### PR DESCRIPTION
Bump `create-tutorialkit-rb` to version 0.1.1.